### PR TITLE
Prefetch images for the next response.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "express": "5",
     "express-handlebars": "^3.0.0",
     "isomorphic-fetch": "^2.2.1",
+    "pson": "^2.0.0",
     "type-is": "^1.6.15"
   },
   "devDependencies": {

--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ app.use(healthcheck())
 
 router.get('/', index)
 router.get('/v1/docs', docs)
-router.get('/v1/image', image)
+router.get('/v1/image', image.cachedImageAction)
 router.get('/*', (req, res) => {
   res.redirect('/v1/docs')
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,9 +684,20 @@ buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
+bufferview@~1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bufferview/-/bufferview-1.0.1.tgz#7afd74a45f937fa422a1d338c08bbfdc76cd725d"
+
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+bytebuffer@~3:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-3.5.5.tgz#7a6faf1a13514b083f1fcf9541c4c9bfbe7e7fd3"
+  dependencies:
+    bufferview "~1"
+    long "~2 >=2.2.3"
 
 bytes@2.4.0:
   version "2.4.0"
@@ -2647,6 +2658,10 @@ log-symbols@^1.0.2:
   dependencies:
     chalk "^1.0.0"
 
+"long@~2 >=2.2.3":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-2.4.0.tgz#9fa180bb1d9500cdc29c4156766a1995e1f4524f"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -3289,6 +3304,12 @@ ps-tree@^1.0.1:
 pseudomap@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+pson@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pson/-/pson-2.0.0.tgz#9200a8b7954a53f0773e3668db0341264595387a"
+  dependencies:
+    bytebuffer "~3"
 
 punycode@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
- Added ability to pre-fetch images for the next response.
- Automatically bucket into 10 buckets, so that we have at max 10 variations in-cache per query.