### PR TITLE
Implement Redis

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
+require('dotenv').config()
 require('./src/main')

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "express-handlebars": "^3.0.0",
     "isomorphic-fetch": "^2.2.1",
     "morgan": "^1.8.2",
-    "pson": "^2.0.0",
+    "msgpack-lite": "^0.1.26",
     "type-is": "^1.6.15",
     "uuid": "^3.1.0",
     "winston": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   "dependencies": {
     "body-parser": "^1.17.1",
     "cors": "^2.8.1",
+    "dotenv": "^4.0.0",
     "express": "v5.0.0-alpha.5",
     "express-handlebars": "^3.0.0",
     "isomorphic-fetch": "^2.2.1",
     "morgan": "^1.8.2",
     "msgpack-lite": "^0.1.26",
+    "redis": "^2.7.1",
     "type-is": "^1.6.15",
     "uuid": "^3.1.0",
     "winston": "^2.3.1",

--- a/src/cache/index.js
+++ b/src/cache/index.js
@@ -2,6 +2,7 @@
 // No-op will always catch, so array always valid.
 const Logger = require('../util/logger')
 const strategies = require('./strategy')
+
 const Strategy = strategies.filter(strategy => strategy.isValid()).shift()
 Logger.info(`Using ${Strategy.name} caching strategy.`)
 module.exports = new Strategy()

--- a/src/cache/index.js
+++ b/src/cache/index.js
@@ -1,5 +1,7 @@
 // Prioritised caching strategies.
 // No-op will always catch, so array always valid.
+const Logger = require('../util/logger')
 const strategies = require('./strategy')
 const Strategy = strategies.filter(strategy => strategy.isValid()).shift()
+Logger.info(`Using ${Strategy.name} caching strategy.`)
 module.exports = new Strategy()

--- a/src/cache/index.js
+++ b/src/cache/index.js
@@ -1,0 +1,5 @@
+// Prioritised caching strategies.
+// No-op will always catch, so array always valid.
+const strategies = require('./strategy')
+const Strategy = strategies.filter(strategy => strategy.isValid()).shift()
+module.exports = new Strategy()

--- a/src/cache/strategy/base-strategy.js
+++ b/src/cache/strategy/base-strategy.js
@@ -1,3 +1,5 @@
+const throwError = val => new Error(`Not implemented: ${val}`)
+
 class BaseStrategy {
 
     static isValid() {
@@ -10,25 +12,25 @@ class BaseStrategy {
 
     has(key) {
         return new Promise((resolve, reject) => {
-            reject(new Error('Not implemented'))
+            reject(throwError({key}))
         })
     }
 
     get(key) {
         return new Promise((resolve, reject) => {
-            reject(new Error('Not implemented'))
+            reject(throwError({key}))
         })
     }
 
     set(key, value) {
         return new Promise((resolve, reject) => {
-            reject(new Error('Not implemented'))
+            reject(throwError({key, value}))
         })
     }
 
     delete(key) {
         return new Promise((resolve, reject) => {
-            reject(new Error('Not implemented'))
+            reject(throwError({key}))
         })
     }
 }

--- a/src/cache/strategy/base-strategy.js
+++ b/src/cache/strategy/base-strategy.js
@@ -1,0 +1,32 @@
+class BaseStrategy {
+
+    static isValid() {
+        return false
+    }
+
+    has(key) {
+        return new Promise((resolve, reject) => {
+            reject(new Error('Not implemented'))
+        })
+    }
+
+    get(key) {
+        return new Promise((resolve, reject) => {
+            reject(new Error('Not implemented'))
+        })
+    }
+
+    set(key, value) {
+        return new Promise((resolve, reject) => {
+            reject(new Error('Not implemented'))
+        })
+    }
+
+    delete(key) {
+        return new Promise((resolve, reject) => {
+            reject(new Error('Not implemented'))
+        })
+    }
+}
+
+module.exports = BaseStrategy

--- a/src/cache/strategy/base-strategy.js
+++ b/src/cache/strategy/base-strategy.js
@@ -4,6 +4,10 @@ class BaseStrategy {
         return false
     }
 
+    static get name() {
+        return 'Base'
+    }
+
     has(key) {
         return new Promise((resolve, reject) => {
             reject(new Error('Not implemented'))

--- a/src/cache/strategy/index.js
+++ b/src/cache/strategy/index.js
@@ -1,0 +1,6 @@
+module.exports = [
+    require('./redis-strategy'),
+    require('./map-strategy'),
+    require('./noop-strategy'),
+    require('./base-strategy'),
+]

--- a/src/cache/strategy/map-strategy.js
+++ b/src/cache/strategy/map-strategy.js
@@ -8,6 +8,10 @@ class MapStrategy extends BaseStrategy
         return process.env.NODE_ENV !== 'development'
     }
 
+    static get name() {
+        return 'Map'
+    }
+
     constructor() {
         super()
         this.map = new Map()

--- a/src/cache/strategy/map-strategy.js
+++ b/src/cache/strategy/map-strategy.js
@@ -19,7 +19,7 @@ class MapStrategy extends BaseStrategy
 
     has(key) {
         return new Promise((resolve, reject) =>
-            this.map.has(key) ? resolve(true) : reject(false)
+            this.map.has(key) ? resolve(true) : reject(new Error(false))
         )
     }
     

--- a/src/cache/strategy/map-strategy.js
+++ b/src/cache/strategy/map-strategy.js
@@ -1,0 +1,35 @@
+const BaseStrategy = require('./base-strategy')
+
+// A Caching strategy relying on Maps.
+// Perfectly adequate, and on by default.
+class MapStrategy extends BaseStrategy
+{
+    static isValid() {
+        return process.env.NODE_ENV !== 'development'
+    }
+
+    constructor() {
+        super()
+        this.map = new Map()
+    }
+
+    has(key) {
+        return new Promise((resolve, reject) =>
+            this.map.has(key) ? resolve(true) : reject(false)
+        )
+    }
+    
+    get(key) {
+        return new Promise(resolve => resolve(this.map.get(key)))
+    }
+
+    set(key, value) {
+        return new Promise(resolve => resolve(this.map.set(key, value)))
+    }
+
+    delete(key) {
+        return new Promise(resolve => resolve(this.map.delete(key)))
+    }
+}
+
+module.exports = MapStrategy

--- a/src/cache/strategy/noop-strategy.js
+++ b/src/cache/strategy/noop-strategy.js
@@ -1,0 +1,26 @@
+const BaseStrategy = require('./base-strategy')
+
+class NoopStrategy extends BaseStrategy
+{
+    static isValid() {
+        return true
+    }
+
+    has(key) {
+        return new Promise((resolve, reject) => reject(false))
+    }
+    
+    get(key) {
+        return new Promise(resolve => resolve())
+    }
+
+    set(key, value) {
+        return new Promise(resolve => resolve())
+    }
+
+    delete(key) {
+        return new Promise(resolve => resolve())
+    }
+}
+
+module.exports =  NoopStrategy

--- a/src/cache/strategy/noop-strategy.js
+++ b/src/cache/strategy/noop-strategy.js
@@ -6,6 +6,10 @@ class NoopStrategy extends BaseStrategy
         return true
     }
 
+    static get name() {
+        return 'No-Op'
+    }
+
     has(key) {
         return new Promise((resolve, reject) => reject(false))
     }

--- a/src/cache/strategy/noop-strategy.js
+++ b/src/cache/strategy/noop-strategy.js
@@ -11,19 +11,19 @@ class NoopStrategy extends BaseStrategy
     }
 
     has(key) {
-        return new Promise((resolve, reject) => reject(false))
+        return new Promise((resolve, reject) => reject(new Error({key})))
     }
     
     get(key) {
-        return new Promise(resolve => resolve())
+        return new Promise(resolve => resolve({key}))
     }
 
     set(key, value) {
-        return new Promise(resolve => resolve())
+        return new Promise(resolve => resolve({key, value}))
     }
 
     delete(key) {
-        return new Promise(resolve => resolve())
+        return new Promise(resolve => resolve({key}))
     }
 }
 

--- a/src/cache/strategy/redis-strategy.js
+++ b/src/cache/strategy/redis-strategy.js
@@ -1,5 +1,5 @@
-const BaseStrategy = require('./base-strategy')
 const redis = require('redis')
+const BaseStrategy = require('./base-strategy')
 
 /**
  * Promise helper to save duplicated RedisClient code.
@@ -24,7 +24,7 @@ class RedisStrategy extends BaseStrategy
     constructor() {
         super()
         this.redisClient = redis.createClient(process.env.REDIS_URL, {
-            detect_buffers: true
+            'detect_buffers': true
         })
     }
 
@@ -40,7 +40,7 @@ class RedisStrategy extends BaseStrategy
     
     get(key) {
         return new Promise((resolve, reject) => {
-            return this.redisClient.get(new Buffer(key), promiseHelper(resolve, reject))
+            return this.redisClient.get(Buffer.from(key), promiseHelper(resolve, reject))
         })
     }
 

--- a/src/cache/strategy/redis-strategy.js
+++ b/src/cache/strategy/redis-strategy.js
@@ -1,0 +1,60 @@
+const BaseStrategy = require('./base-strategy')
+const redis = require('redis')
+
+/**
+ * Promise helper to save duplicated RedisClient code.
+ * @param {function} resolve 
+ * @param {function} reject 
+ * @param {function|undefined} A function to verify a Redis response with.
+ */
+const promiseHelper = (resolve, reject, cb) => (
+    (err, res) => (err || cb && cb(res)) ? reject(err) : resolve(res)
+)
+
+class RedisStrategy extends BaseStrategy
+{
+    static isValid() {
+        return 'REDIS_URL' in process.env
+    }
+
+    static get name() {
+        return 'Redis'
+    }
+
+    constructor() {
+        super()
+        this.redisClient = redis.createClient(process.env.REDIS_URL, {
+            detect_buffers: true
+        })
+    }
+
+    has(key) {
+        return new Promise((resolve, reject) => {
+            this.redisClient.exists(
+                key,
+                // Provided no error, we want to reject when no key is found (res 0).
+                promiseHelper(resolve, reject, res => res === 0)
+            )
+        })
+    }
+    
+    get(key) {
+        return new Promise((resolve, reject) => {
+            return this.redisClient.get(new Buffer(key), promiseHelper(resolve, reject))
+        })
+    }
+
+    set(key, value) {
+        return new Promise((resolve, reject) => {
+            this.redisClient.set(key, value, promiseHelper(resolve, reject))
+        })
+    }
+
+    delete(key) {
+        return new Promise((resolve, reject) => {
+            this.redisClient.del(key, promiseHelper(resolve, reject))
+        })
+    }
+}
+
+module.exports = RedisStrategy

--- a/src/main.js
+++ b/src/main.js
@@ -37,7 +37,7 @@ app.use(router)
 
 router.get('/', index)
 router.get('/v1/docs', docs)
-router.get('/v1/image', image.cachedImageAction)
+router.get('/v1/image', image)
 router.get('/:width(\\d+)/:height(\\d+)', imageShorthand)
 router.get('/*', (req, res) => res.redirect('/v1/docs'))
 

--- a/src/main.js
+++ b/src/main.js
@@ -22,10 +22,14 @@ app.engine('.html', expressHandlebars({
 }))
 app.set('view engine', '.html')
 
-app.use(morgan('dev', {stream: logger.stream}))
 app.use(cors())
 app.use(bodyParser.json())
 app.use(requestId)
+morgan.token('id', req => req.id)
+app.use(morgan('[:id] :remote-addr :method :url', {
+    immediate: true,
+    stream: logger.stream
+}))
 app.use(requestLogger)
 app.use(requestFormat())
 app.use(healthcheck())

--- a/src/middleware/request-logger.js
+++ b/src/middleware/request-logger.js
@@ -1,6 +1,6 @@
 const logger = require('../util/logger')
 
 module.exports = (req, res, next) => {
-  req.log = message => logger.info(`${req.id} ${message}`)
+  req.log = message => logger.info(`[${req.id}] ${message}`)
   next()
 }

--- a/src/routes/image.js
+++ b/src/routes/image.js
@@ -2,11 +2,13 @@ const fetch = require('isomorphic-fetch')
 const msgpack = require('msgpack-lite')
 const cache = require('../cache')
 
+const noop = _ => (undefined)
+
 // Skeleton Query used for search.
 class Query {
     constructor(params) {
         this.category = params.category || 'buildings'
-        this.bucket = `random-${Math.floor(Math.random()*4)}-v1`
+        this.bucket = `random-${Math.floor(Math.random()*10)}-v1`
         this.size = {
             width: params.width || 1920,
             height: params.height || 1200
@@ -89,7 +91,7 @@ function imageAction(req, res, next) {
         .then(msgpack.decode)
         .then(sendResponse)
         .then(_ => cache.delete(query.hash))
-        .catch(_ => req.log('No variation found.'))
+        .catch(noop)
 
         // Perform our Provider callout.
         .then(_ => getImageFromProvider(query))

--- a/src/routes/image.js
+++ b/src/routes/image.js
@@ -5,26 +5,38 @@ const encoder = new ProgressivePair([])
 const nextResponse = new Map()
 
 // Skeleton Query used for search.
-
-const getQueryFromParams = params => ({
-    category: params.category || 'buildings',
-    bucket: `random-${Math.floor(Math.random()*4)}-v1`,
-    size: {
-        width: params.width || 1920,
-        height: params.height || 1200
+class Query {
+    constructor(params) {
+        this.category = params.category || 'buildings'
+        this.bucket = `random-${Math.floor(Math.random()*4)}-v1`
+        this.size = {
+            width: params.width || 1920,
+            height: params.height || 1200
+        }
     }
-})
+
+    get hash() {
+        return `${this.category}-${this.bucket}-${this.size.width}x${this.size.height}`
+    }
+}
 
 const responseBody = {
     provider: 'unsplash',
     license: 'CC0',
     terms: 'https://unsplash.com/terms',
-    url: ''
+    url: '',
+    size: {
+        width: 0,
+        height: 0
+    }
 }
-const getResponseBodyFromUrl = url => Object.assign(responseBody, {url})
+const getResponseBody = res => Object.assign(responseBody, res)
 const getImageFromProvider = query => (
     fetch(`https://source.unsplash.com/category/${query.category}/${query.size.width}x${query.size.height}`)
-        .then(res => getResponseBodyFromUrl(res.url))
+    .then(res => getResponseBody({
+        url: res.url,
+        size: query.size
+    }))
 )
 
 
@@ -33,10 +45,10 @@ function cachedImageAction(req, res, next) {
     // Define logic for sending a response.
     const sendResponse = responseBody => {
 
+        req.log(JSON.stringify(responseBody))
+
         // Bail if we've already served this response.
         if (res.headersSent) return
-
-        req.log(JSON.stringify(responseBody))
 
         // We don't want clients to cache this response.
         res.setHeader('Cache-Control', 'no-cache')
@@ -64,22 +76,20 @@ function cachedImageAction(req, res, next) {
     }
 
     // Grab query from request, and generate a hash for caching.
-    const paramsMergedWithQuery = Object.assign(req.params, req.query)
-    const query = getQueryFromParams(paramsMergedWithQuery)
-    const queryHash = encoder.encode(query).toString('hex')
-    req.log(JSON.stringify(query))
+    const query = new Query(Object.assign(req.params, req.query))
+    req.log(JSON.stringify(query.hash))
 
     // If we already have a response with this key, send that response.
-    if (nextResponse.has(queryHash)) {
-        const response = nextResponse.get(queryHash)
-        nextResponse.delete(queryHash)
+    if (nextResponse.has(query.hash)) {
+        const response = nextResponse.get(query.hash)
+        nextResponse.delete(query.hash)
         sendResponse(response)
     }
 
     return getImageFromProvider(query)
         // If this query is cacheable, store it for a future request.
         .then(responseBody => {
-            if (req.cacheable !== false) nextResponse.set(queryHash, responseBody)
+            if (req.cacheable !== false) nextResponse.set(query.hash, responseBody)
             return responseBody
         })
         .then(sendResponse)

--- a/src/routes/image.js
+++ b/src/routes/image.js
@@ -72,17 +72,11 @@ function imageAction(req, res, next) {
             default:
                 throw new Error('Unexpected Content-Type')
         }
-        return
     }
 
     // Grab query from request, and generate a hash for caching.
     const query = new Query(Object.assign(req.params, req.query))
     req.log(JSON.stringify(query.hash))
-
-    const log = function() {
-        console.log(arguments)
-        return arguments
-    }
 
     // A massive promise chain, so we can access asynch caches.
     // If we already have a response with this key, send that response.

--- a/yarn.lock
+++ b/yarn.lock
@@ -692,20 +692,9 @@ buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
-bufferview@~1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/bufferview/-/bufferview-1.0.1.tgz#7afd74a45f937fa422a1d338c08bbfdc76cd725d"
-
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
-
-bytebuffer@~3:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-3.5.5.tgz#7a6faf1a13514b083f1fcf9541c4c9bfbe7e7fd3"
-  dependencies:
-    bufferview "~1"
-    long "~2 >=2.2.3"
 
 bytes@2.4.0:
   version "2.4.0"
@@ -1518,6 +1507,10 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+event-lite@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/event-lite/-/event-lite-0.1.1.tgz#47cf08a8d37d0b694cdb7b3b17b51faac6576086"
+
 event-stream@~3.3.0:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
@@ -2060,6 +2053,10 @@ iconv-lite@0.4.15, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
+ieee754@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+
 ignore-by-default@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
@@ -2118,6 +2115,10 @@ inquirer@^0.12.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.0"
     through "^2.3.6"
+
+int64-buffer@^0.1.9:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.9.tgz#9e039da043b24f78b196b283e04653ef5e990f61"
 
 interpret@^1.0.0:
   version "1.0.3"
@@ -2688,10 +2689,6 @@ log-symbols@^1.0.2:
   dependencies:
     chalk "^1.0.0"
 
-"long@~2 >=2.2.3":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-2.4.0.tgz#9fa180bb1d9500cdc29c4156766a1995e1f4524f"
-
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -2854,6 +2851,15 @@ ms@0.7.2, ms@^0.7.1:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+msgpack-lite@^0.1.26:
+  version "0.1.26"
+  resolved "https://registry.yarnpkg.com/msgpack-lite/-/msgpack-lite-0.1.26.tgz#dd3c50b26f059f25e7edee3644418358e2a9ad89"
+  dependencies:
+    event-lite "^0.1.1"
+    ieee754 "^1.1.8"
+    int64-buffer "^0.1.9"
+    isarray "^1.0.0"
 
 multimatch@^2.1.0:
   version "2.1.0"
@@ -3352,12 +3358,6 @@ ps-tree@^1.0.1:
 pseudomap@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-
-pson@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pson/-/pson-2.0.0.tgz#9200a8b7954a53f0773e3668db0341264595387a"
-  dependencies:
-    bytebuffer "~3"
 
 punycode@^1.4.1:
   version "1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,6 +1176,14 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
+
+double-ended-queue@^2.1.0-0:
+  version "2.1.0-0"
+  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -3473,6 +3481,22 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+redis-commands@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.3.1.tgz#81d826f45fa9c8b2011f4cd7a0fe597d241d442b"
+
+redis-parser@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
+
+redis@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-2.7.1.tgz#7d56f7875b98b20410b71539f1d878ed58ebf46a"
+  dependencies:
+    double-ended-queue "^2.1.0-0"
+    redis-commands "^1.2.0"
+    redis-parser "^2.5.0"
 
 regenerate@^1.2.1:
   version "1.3.2"


### PR DESCRIPTION
This implements improves logging, implements the following cache strategies: No-Op, Map and Redis.
Redis can be enabled by setting a REDIS_URL environment variable.  No validation is performed on the URL, as RedisClient will throw an exception on launch.

Objectives:

- Persistent cache-pool, so that scaling, deployments and restarts are not a concern.
- Resolve memory corruption issue, wherein image sizes and categories are not respected.